### PR TITLE
Remove unsupported candle intervals

### DIFF
--- a/src/Tinkoff.Trading.OpenApi/Models/CandleInterval.cs
+++ b/src/Tinkoff.Trading.OpenApi/Models/CandleInterval.cs
@@ -23,10 +23,6 @@ namespace Tinkoff.Trading.OpenApi.Models
         HalfHour,
         [EnumMember(Value = "hour")]
         Hour,
-        [EnumMember(Value = "2hour")]
-        TwoHours,
-        [EnumMember(Value = "4hour")]
-        FourHours,
         [EnumMember(Value = "day")]
         Day,
         [EnumMember(Value = "week")]


### PR DESCRIPTION
Согласно API интервалы 2 и 4 часа не поддерживаются.
https://tinkoffcreditsystems.github.io/invest-openapi/swagger-ui/#/