### PR TITLE
Migrate from Newtonsoft.Json to System.Text.Json

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -11,12 +11,20 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    env:
+      DOTNET_NOLOGO: true
+      DOTNET_CLI_TELEMETRY_OPTOUT: true
+
     steps:
     - uses: actions/checkout@v2
-    - name: Setup .NET Core
+    - name: Setup .NET 5
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.301
+        dotnet-version: 5.0.x
+    - name: Setup .NET Core 3.1
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.x
     - name: Install dependencies
       run: dotnet restore
     - name: Build

--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ docker run --rm  -v "$PWD":/home/dotnet/project -w  /home/dotnet/project mcr.mic
 
 ## Документация
 
-Единственная зависимость проекта — Json.NET для работы с JSON.
 Документацию непосредственно по OpenAPI можно найти по [ссылке](https://api-invest.tinkoff.ru/openapi/docs/).
 
 ### Быстрый старт

--- a/src/Tinkoff.Trading.OpenApi/Models/BrokerAccountType.cs
+++ b/src/Tinkoff.Trading.OpenApi/Models/BrokerAccountType.cs
@@ -1,9 +1,8 @@
-﻿using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
+﻿using System.Text.Json.Serialization;
 
 namespace Tinkoff.Trading.OpenApi.Models
 {
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     public enum BrokerAccountType
     {
         Tinkoff = 1,

--- a/src/Tinkoff.Trading.OpenApi/Models/CandleInterval.cs
+++ b/src/Tinkoff.Trading.OpenApi/Models/CandleInterval.cs
@@ -1,10 +1,9 @@
 using System.Runtime.Serialization;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
+using System.Text.Json.Serialization;
 
 namespace Tinkoff.Trading.OpenApi.Models
 {
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(JsonStringEnumMemberConverter))]
     public enum CandleInterval
     {
         [EnumMember(Value = "1min")]

--- a/src/Tinkoff.Trading.OpenApi/Models/CandleList.cs
+++ b/src/Tinkoff.Trading.OpenApi/Models/CandleList.cs
@@ -1,5 +1,5 @@
 using System.Collections.Generic;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Tinkoff.Trading.OpenApi.Models
 {
@@ -8,7 +8,7 @@ namespace Tinkoff.Trading.OpenApi.Models
         public string Figi { get; }
         public CandleInterval Interval { get; }
         public List<CandlePayload> Candles { get; }
-        
+
         [JsonConstructor]
         public CandleList(string figi, CandleInterval interval, List<CandlePayload> candles)
         {

--- a/src/Tinkoff.Trading.OpenApi/Models/CandlePayload.cs
+++ b/src/Tinkoff.Trading.OpenApi/Models/CandlePayload.cs
@@ -1,14 +1,19 @@
 using System;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Tinkoff.Trading.OpenApi.Models
 {
     public class CandlePayload
     {
+        [JsonPropertyName("o")]
         public decimal Open { get; }
+        [JsonPropertyName("c")]
         public decimal Close { get; }
+        [JsonPropertyName("h")]
         public decimal High { get; }
+        [JsonPropertyName("l")]
         public decimal Low { get; }
+        [JsonPropertyName("v")]
         public decimal Volume { get; }
         public DateTime Time { get; }
         public CandleInterval Interval { get; }
@@ -16,11 +21,11 @@ namespace Tinkoff.Trading.OpenApi.Models
 
         [JsonConstructor]
         public CandlePayload(
-            [JsonProperty("o")] decimal open,
-            [JsonProperty("c")] decimal close,
-            [JsonProperty("h")] decimal high,
-            [JsonProperty("l")] decimal low,
-            [JsonProperty("v")] decimal volume,
+            decimal open,
+            decimal close,
+            decimal high,
+            decimal low,
+            decimal volume,
             DateTime time,
             CandleInterval interval,
             string figi)

--- a/src/Tinkoff.Trading.OpenApi/Models/CandleResponse.cs
+++ b/src/Tinkoff.Trading.OpenApi/Models/CandleResponse.cs
@@ -1,6 +1,5 @@
 using System;
-
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Tinkoff.Trading.OpenApi.Models
 {

--- a/src/Tinkoff.Trading.OpenApi/Models/Currency.cs
+++ b/src/Tinkoff.Trading.OpenApi/Models/Currency.cs
@@ -1,10 +1,9 @@
 using System.Runtime.Serialization;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
+using System.Text.Json.Serialization;
 
 namespace Tinkoff.Trading.OpenApi.Models
 {
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(JsonStringEnumMemberConverter))]
     public enum Currency
     {
         [EnumMember(Value = "RUB")] Rub,

--- a/src/Tinkoff.Trading.OpenApi/Models/ExtendedOperationType.cs
+++ b/src/Tinkoff.Trading.OpenApi/Models/ExtendedOperationType.cs
@@ -1,9 +1,8 @@
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
+using System.Text.Json.Serialization;
 
 namespace Tinkoff.Trading.OpenApi.Models
 {
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     public enum ExtendedOperationType
     {
         Buy,

--- a/src/Tinkoff.Trading.OpenApi/Models/InstrumentInfoPayload.cs
+++ b/src/Tinkoff.Trading.OpenApi/Models/InstrumentInfoPayload.cs
@@ -1,25 +1,36 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Tinkoff.Trading.OpenApi.Models
 {
     public class InstrumentInfoPayload
     {
+        [JsonPropertyName("trade_status")]
         public string TradeStatus { get; }
+
+        [JsonPropertyName("min_price_increment")]
         public decimal MinPriceIncrement { get; }
+
         public int Lot { get; }
+
+        [JsonPropertyName("accrued_interest")]
         public decimal AccruedInterest { get; }
+
+        [JsonPropertyName("limit_up")]
         public decimal LimitUp { get; }
+
+        [JsonPropertyName("limit_down")]
         public decimal LimitDown { get; }
+
         public string Figi { get; }
 
         [JsonConstructor]
         public InstrumentInfoPayload(
-            [JsonProperty("trade_status")] string tradeStatus,
-            [JsonProperty("min_price_increment")] decimal minPriceIncrement,
+            string tradeStatus,
+            decimal minPriceIncrement,
             int lot,
-            [JsonProperty("accrued_interest")] decimal accruedInterest,
-            [JsonProperty("limit_up")] decimal limitUp,
-            [JsonProperty("limit_down")] decimal limitDown,
+            decimal accruedInterest,
+            decimal limitUp,
+            decimal limitDown,
             string figi)
         {
             TradeStatus = tradeStatus;

--- a/src/Tinkoff.Trading.OpenApi/Models/InstrumentInfoResponse.cs
+++ b/src/Tinkoff.Trading.OpenApi/Models/InstrumentInfoResponse.cs
@@ -1,6 +1,5 @@
 using System;
-
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Tinkoff.Trading.OpenApi.Models
 {

--- a/src/Tinkoff.Trading.OpenApi/Models/InstrumentType.cs
+++ b/src/Tinkoff.Trading.OpenApi/Models/InstrumentType.cs
@@ -1,5 +1,8 @@
+using System.Text.Json.Serialization;
+
 namespace Tinkoff.Trading.OpenApi.Models
 {
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     public enum InstrumentType
     {
         Stock,

--- a/src/Tinkoff.Trading.OpenApi/Models/MarketInstrument.cs
+++ b/src/Tinkoff.Trading.OpenApi/Models/MarketInstrument.cs
@@ -1,4 +1,4 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Tinkoff.Trading.OpenApi.Models
 {

--- a/src/Tinkoff.Trading.OpenApi/Models/MarketInstrumentList.cs
+++ b/src/Tinkoff.Trading.OpenApi/Models/MarketInstrumentList.cs
@@ -1,5 +1,5 @@
 using System.Collections.Generic;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Tinkoff.Trading.OpenApi.Models
 {

--- a/src/Tinkoff.Trading.OpenApi/Models/MoneyAmount.cs
+++ b/src/Tinkoff.Trading.OpenApi/Models/MoneyAmount.cs
@@ -1,4 +1,4 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Tinkoff.Trading.OpenApi.Models
 {

--- a/src/Tinkoff.Trading.OpenApi/Models/OpenApiExceptionPayload.cs
+++ b/src/Tinkoff.Trading.OpenApi/Models/OpenApiExceptionPayload.cs
@@ -1,4 +1,4 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Tinkoff.Trading.OpenApi.Models
 {

--- a/src/Tinkoff.Trading.OpenApi/Models/OpenApiResponse.cs
+++ b/src/Tinkoff.Trading.OpenApi/Models/OpenApiResponse.cs
@@ -1,4 +1,4 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Tinkoff.Trading.OpenApi.Models
 {

--- a/src/Tinkoff.Trading.OpenApi/Models/Operation.cs
+++ b/src/Tinkoff.Trading.OpenApi/Models/Operation.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Tinkoff.Trading.OpenApi.Models
 {

--- a/src/Tinkoff.Trading.OpenApi/Models/OperationStatus.cs
+++ b/src/Tinkoff.Trading.OpenApi/Models/OperationStatus.cs
@@ -1,9 +1,8 @@
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
+using System.Text.Json.Serialization;
 
 namespace Tinkoff.Trading.OpenApi.Models
 {
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     public enum OperationStatus
     {
         Done,

--- a/src/Tinkoff.Trading.OpenApi/Models/OperationType.cs
+++ b/src/Tinkoff.Trading.OpenApi/Models/OperationType.cs
@@ -1,9 +1,8 @@
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
+using System.Text.Json.Serialization;
 
 namespace Tinkoff.Trading.OpenApi.Models
 {
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     public enum OperationType
     {
         Buy,

--- a/src/Tinkoff.Trading.OpenApi/Models/Order.cs
+++ b/src/Tinkoff.Trading.OpenApi/Models/Order.cs
@@ -1,4 +1,4 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Tinkoff.Trading.OpenApi.Models
 {

--- a/src/Tinkoff.Trading.OpenApi/Models/OrderStatus.cs
+++ b/src/Tinkoff.Trading.OpenApi/Models/OrderStatus.cs
@@ -1,9 +1,8 @@
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
+using System.Text.Json.Serialization;
 
 namespace Tinkoff.Trading.OpenApi.Models
 {
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     public enum OrderStatus
     {
         New,

--- a/src/Tinkoff.Trading.OpenApi/Models/OrderType.cs
+++ b/src/Tinkoff.Trading.OpenApi/Models/OrderType.cs
@@ -1,9 +1,8 @@
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
+using System.Text.Json.Serialization;
 
 namespace Tinkoff.Trading.OpenApi.Models
 {
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     public enum OrderType
     {
         Limit,

--- a/src/Tinkoff.Trading.OpenApi/Models/Orderbook.cs
+++ b/src/Tinkoff.Trading.OpenApi/Models/Orderbook.cs
@@ -1,5 +1,5 @@
 using System.Collections.Generic;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Tinkoff.Trading.OpenApi.Models
 {

--- a/src/Tinkoff.Trading.OpenApi/Models/OrderbookPayload.cs
+++ b/src/Tinkoff.Trading.OpenApi/Models/OrderbookPayload.cs
@@ -1,5 +1,5 @@
 using System.Collections.Generic;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Tinkoff.Trading.OpenApi.Models
 {

--- a/src/Tinkoff.Trading.OpenApi/Models/OrderbookRecord.cs
+++ b/src/Tinkoff.Trading.OpenApi/Models/OrderbookRecord.cs
@@ -1,4 +1,4 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Tinkoff.Trading.OpenApi.Models
 {

--- a/src/Tinkoff.Trading.OpenApi/Models/OrderbookResponse.cs
+++ b/src/Tinkoff.Trading.OpenApi/Models/OrderbookResponse.cs
@@ -1,6 +1,5 @@
 using System;
-
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Tinkoff.Trading.OpenApi.Models
 {

--- a/src/Tinkoff.Trading.OpenApi/Models/PlacedLimitOrder.cs
+++ b/src/Tinkoff.Trading.OpenApi/Models/PlacedLimitOrder.cs
@@ -1,4 +1,4 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Tinkoff.Trading.OpenApi.Models
 {

--- a/src/Tinkoff.Trading.OpenApi/Models/PlacedMarketOrder.cs
+++ b/src/Tinkoff.Trading.OpenApi/Models/PlacedMarketOrder.cs
@@ -1,4 +1,4 @@
-﻿﻿using Newtonsoft.Json;
+﻿﻿using System.Text.Json.Serialization;
 
 namespace Tinkoff.Trading.OpenApi.Models
 {

--- a/src/Tinkoff.Trading.OpenApi/Models/Portfolio.cs
+++ b/src/Tinkoff.Trading.OpenApi/Models/Portfolio.cs
@@ -1,5 +1,5 @@
 using System.Collections.Generic;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Tinkoff.Trading.OpenApi.Models
 {

--- a/src/Tinkoff.Trading.OpenApi/Models/PortfolioCurrency.cs
+++ b/src/Tinkoff.Trading.OpenApi/Models/PortfolioCurrency.cs
@@ -1,5 +1,5 @@
 using System.Collections.Generic;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Tinkoff.Trading.OpenApi.Models
 {

--- a/src/Tinkoff.Trading.OpenApi/Models/SandboxAccount.cs
+++ b/src/Tinkoff.Trading.OpenApi/Models/SandboxAccount.cs
@@ -1,6 +1,4 @@
-﻿using Newtonsoft.Json.Serialization;
-
-namespace Tinkoff.Trading.OpenApi.Models
+﻿namespace Tinkoff.Trading.OpenApi.Models
 {
     /// <summary>
     /// Данные счета песочницы

--- a/src/Tinkoff.Trading.OpenApi/Models/StreamingErrorPayload.cs
+++ b/src/Tinkoff.Trading.OpenApi/Models/StreamingErrorPayload.cs
@@ -1,16 +1,19 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Tinkoff.Trading.OpenApi.Models
 {
     public class StreamingErrorPayload
     {
+        [JsonPropertyName("error")]
         public string Error { get; }
+
+        [JsonPropertyName("request_id")]
         public string RequestId { get; }
 
         [JsonConstructor]
         public StreamingErrorPayload(
-            [JsonProperty("error")] string error,
-            [JsonProperty("request_id")] string requestId)
+            string error,
+            string requestId)
         {
             Error = error;
             RequestId = requestId;

--- a/src/Tinkoff.Trading.OpenApi/Models/StreamingErrorResponse.cs
+++ b/src/Tinkoff.Trading.OpenApi/Models/StreamingErrorResponse.cs
@@ -1,6 +1,5 @@
 using System;
-
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Tinkoff.Trading.OpenApi.Models
 {

--- a/src/Tinkoff.Trading.OpenApi/Models/StreamingRequest.cs
+++ b/src/Tinkoff.Trading.OpenApi/Models/StreamingRequest.cs
@@ -1,13 +1,13 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Tinkoff.Trading.OpenApi.Models
 {
     public abstract class StreamingRequest
     {
-        [JsonProperty(PropertyName = "event")]
+        [JsonPropertyName("event")]
         public abstract string Event { get; }
 
-        [JsonProperty(PropertyName = "request_id")]
+        [JsonPropertyName("request_id")]
         public string RequestId { get; }
 
         protected StreamingRequest(string requestId)
@@ -49,10 +49,10 @@ namespace Tinkoff.Trading.OpenApi.Models
         {
             public override string Event => "candle:subscribe";
 
-            [JsonProperty(PropertyName = "figi")]
+            [JsonPropertyName("figi")]
             public string Figi { get; }
 
-            [JsonProperty(PropertyName = "interval")]
+            [JsonPropertyName("interval")]
             public CandleInterval Interval { get; }
 
             public CandleSubscribeRequest(string figi, CandleInterval interval, string requestId = null)
@@ -67,10 +67,10 @@ namespace Tinkoff.Trading.OpenApi.Models
         {
             public override string Event => "candle:unsubscribe";
 
-            [JsonProperty(PropertyName = "figi")]
+            [JsonPropertyName("figi")]
             public string Figi { get; }
 
-            [JsonProperty(PropertyName = "interval")]
+            [JsonPropertyName("interval")]
             public CandleInterval Interval { get; }
 
             public CandleUnsubscribeRequest(string figi, CandleInterval interval, string requestId = null)
@@ -85,10 +85,10 @@ namespace Tinkoff.Trading.OpenApi.Models
         {
             public override string Event => "orderbook:subscribe";
 
-            [JsonProperty(PropertyName = "figi")]
+            [JsonPropertyName("figi")]
             public string Figi { get; }
 
-            [JsonProperty(PropertyName = "depth")]
+            [JsonPropertyName("depth")]
             public int Depth { get; }
 
             public OrderbookSubscribeRequest(string figi, int depth, string requestId = null)
@@ -103,10 +103,10 @@ namespace Tinkoff.Trading.OpenApi.Models
         {
             public override string Event => "orderbook:unsubscribe";
 
-            [JsonProperty(PropertyName = "figi")]
+            [JsonPropertyName("figi")]
             public string Figi { get; }
 
-            [JsonProperty(PropertyName = "depth")]
+            [JsonPropertyName("depth")]
             public int Depth { get; }
 
             public OrderbookUnsubscribeRequest(string figi, int depth, string requestId = null)
@@ -121,7 +121,7 @@ namespace Tinkoff.Trading.OpenApi.Models
         {
             public override string Event => "instrument_info:subscribe";
 
-            [JsonProperty(PropertyName = "figi")]
+            [JsonPropertyName("figi")]
             public string Figi { get; }
 
             public InstrumentInfoSubscribeRequest(string figi, string requestId = null)
@@ -135,7 +135,7 @@ namespace Tinkoff.Trading.OpenApi.Models
         {
             public override string Event => "instrument_info:unsubscribe";
 
-            [JsonProperty(PropertyName = "figi")]
+            [JsonPropertyName("figi")]
             public string Figi { get; }
 
             public InstrumentInfoUnsubscribeRequest(string figi, string requestId = null)

--- a/src/Tinkoff.Trading.OpenApi/Models/StreamingResponse.cs
+++ b/src/Tinkoff.Trading.OpenApi/Models/StreamingResponse.cs
@@ -1,6 +1,5 @@
 using System;
-
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Tinkoff.Trading.OpenApi.Models
 {

--- a/src/Tinkoff.Trading.OpenApi/Models/StreamingResponseConverter.cs
+++ b/src/Tinkoff.Trading.OpenApi/Models/StreamingResponseConverter.cs
@@ -1,55 +1,72 @@
 using System;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
-using Newtonsoft.Json.Serialization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Tinkoff.Trading.OpenApi.Models
 {
-    class StreamingResponseConverter : JsonConverter
+    internal class StreamingResponseConverter : JsonConverter<StreamingResponse>
     {
-        private static readonly JsonSerializerSettings Settings = new JsonSerializerSettings
+        public override StreamingResponse Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options)
         {
-            ContractResolver = new BaseSpecifiedConcreteClassConverter()
-        };
-
-        public override bool CanWrite => false;
-
-        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
-        {
-            throw new NotImplementedException();
-        }
-
-        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
-        {
-            var jsonObject = JObject.Load(reader);
-            switch (jsonObject["event"].Value<string>())
+            string type = string.Empty;
+            DateTime dateTime = default;
+            JsonDocument payload = null;
+            while (reader.Read())
             {
-                case "candle":
-                    return JsonConvert.DeserializeObject<CandleResponse>(jsonObject.ToString(), Settings);
-                case "orderbook":
-                    return JsonConvert.DeserializeObject<OrderbookResponse>(jsonObject.ToString(), Settings);
-                case "instrument_info":
-                    return JsonConvert.DeserializeObject<InstrumentInfoResponse>(jsonObject.ToString(), Settings);
-                case "error":
-                    return JsonConvert.DeserializeObject<StreamingErrorResponse>(jsonObject.ToString(), Settings);
-                default:
-                    throw new ArgumentOutOfRangeException();
+                if (reader.TokenType == JsonTokenType.PropertyName && reader.GetString() == "event")
+                {
+                    reader.Read();
+                    type = reader.GetString();
+
+                    continue;
+                }
+
+                if (reader.TokenType == JsonTokenType.PropertyName && reader.GetString() == "time")
+                {
+                    reader.Read();
+                    dateTime = reader.GetDateTime();
+
+                    continue;
+                }
+
+                if (reader.TokenType == JsonTokenType.PropertyName && reader.GetString() == "payload")
+                {
+                    reader.Read();
+                    payload = JsonDocument.ParseValue(ref reader);
+                    continue;
+                }
+
+                if (!string.IsNullOrEmpty(type) && payload != null && dateTime != default)
+                {
+                    var rawPayload = payload.RootElement.GetRawText();
+
+                    switch (type)
+                    {
+                        case "candle":
+                            return new CandleResponse(JsonSerializer.Deserialize<CandlePayload>(rawPayload, options), dateTime);
+                        case "orderbook":
+                            return new OrderbookResponse(JsonSerializer.Deserialize<OrderbookPayload>(rawPayload, options), dateTime);
+                        case "instrument_info":
+                            return new InstrumentInfoResponse(JsonSerializer.Deserialize<InstrumentInfoPayload>(rawPayload, options), dateTime);
+                        case "error":
+                            return new StreamingErrorResponse(JsonSerializer.Deserialize<StreamingErrorPayload>(rawPayload, options), dateTime);
+                        default:
+                            throw new ArgumentOutOfRangeException();
+                    }
+                }
+
+                continue;
             }
+
+            throw new JsonException();
         }
 
-        public override bool CanConvert(Type objectType)
+        public override void Write(Utf8JsonWriter writer, StreamingResponse value, JsonSerializerOptions options)
         {
-            return objectType == typeof(StreamingResponse);
-        }
-
-        private class BaseSpecifiedConcreteClassConverter : DefaultContractResolver
-        {
-            protected override JsonConverter ResolveContractConverter(Type objectType)
-            {
-                if (typeof(StreamingResponse).IsAssignableFrom(objectType) && !objectType.IsAbstract)
-                    return null;
-                return base.ResolveContractConverter(objectType);
-            }
+            throw new NotSupportedException();
         }
     }
 }

--- a/src/Tinkoff.Trading.OpenApi/Models/Trade.cs
+++ b/src/Tinkoff.Trading.OpenApi/Models/Trade.cs
@@ -1,5 +1,5 @@
 using System;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Tinkoff.Trading.OpenApi.Models
 {

--- a/src/Tinkoff.Trading.OpenApi/Models/TradeStatus.cs
+++ b/src/Tinkoff.Trading.OpenApi/Models/TradeStatus.cs
@@ -1,9 +1,8 @@
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
+using System.Text.Json.Serialization;
 
 namespace Tinkoff.Trading.OpenApi.Models
 {
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     public enum TradeStatus
     {
         NormalTrading,

--- a/src/Tinkoff.Trading.OpenApi/Network/Context.cs
+++ b/src/Tinkoff.Trading.OpenApi/Network/Context.cs
@@ -2,9 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Net.WebSockets;
 using System.Text;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using System.Web;
-using Newtonsoft.Json;
 using Tinkoff.Trading.OpenApi.Models;
 
 namespace Tinkoff.Trading.OpenApi.Network
@@ -244,13 +244,13 @@ namespace Tinkoff.Trading.OpenApi.Network
 
         private class LimitOrderBody
         {
-            [JsonProperty(PropertyName = "lots")]
+            [JsonPropertyName("lots")]
             public int Lots { get; }
 
-            [JsonProperty(PropertyName = "operation")]
+            [JsonPropertyName("operation")]
             public OperationType Operation { get; }
 
-            [JsonProperty(PropertyName = "price")]
+            [JsonPropertyName("price")]
             public decimal Price { get; }
 
             public LimitOrderBody(int lots, OperationType operation, decimal price)
@@ -263,10 +263,10 @@ namespace Tinkoff.Trading.OpenApi.Network
 
         private class MarketOrderBody
         {
-            [JsonProperty(PropertyName = "lots")]
+            [JsonPropertyName("lots")]
             public int Lots { get; }
 
-            [JsonProperty(PropertyName = "operation")]
+            [JsonPropertyName("operation")]
             public OperationType Operation { get; }
 
             public MarketOrderBody(int lots, OperationType operation)

--- a/src/Tinkoff.Trading.OpenApi/Network/SandboxContext.cs
+++ b/src/Tinkoff.Trading.OpenApi/Network/SandboxContext.cs
@@ -1,6 +1,6 @@
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
+
 using Tinkoff.Trading.OpenApi.Models;
 
 namespace Tinkoff.Trading.OpenApi.Network
@@ -53,7 +53,6 @@ namespace Tinkoff.Trading.OpenApi.Network
                 .ConfigureAwait(false);
         }
 
-        [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
         private class SandboxRegisterRequest
         {
             public SandboxRegisterRequest(BrokerAccountType brokerAccountType)
@@ -61,15 +60,16 @@ namespace Tinkoff.Trading.OpenApi.Network
                 BrokerAccountType = brokerAccountType;
             }
 
+            [JsonPropertyName("brokerAccountType")]
             public BrokerAccountType BrokerAccountType { get; }
         }
 
         private class CurrencyBalance
         {
-            [JsonProperty(PropertyName = "currency")]
+            [JsonPropertyName("currency")]
             public Currency Currency { get; }
 
-            [JsonProperty(PropertyName = "balance")]
+            [JsonPropertyName("balance")]
             public decimal Balance { get; }
 
             public CurrencyBalance(Currency currency, decimal balance)
@@ -81,10 +81,10 @@ namespace Tinkoff.Trading.OpenApi.Network
 
         private class PositionBalance
         {
-            [JsonProperty(PropertyName = "figi")]
+            [JsonPropertyName("figi")]
             public string Figi { get; }
 
-            [JsonProperty(PropertyName = "balance")]
+            [JsonPropertyName("balance")]
             public decimal Balance { get; }
 
             public PositionBalance(string figi, decimal balance)

--- a/src/Tinkoff.Trading.OpenApi/SerializationOptions.cs
+++ b/src/Tinkoff.Trading.OpenApi/SerializationOptions.cs
@@ -1,0 +1,9 @@
+﻿using System.Text.Json;
+
+namespace Tinkoff.Trading.OpenApi
+{
+    internal class SerializationOptions
+    {
+        public static JsonSerializerOptions Instance { get; } = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+    }
+}

--- a/src/Tinkoff.Trading.OpenApi/Tinkoff.Trading.OpenApi.csproj
+++ b/src/Tinkoff.Trading.OpenApi/Tinkoff.Trading.OpenApi.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
         <Company>Tinkoff</Company>
         <PackageVersion>1.6.0</PackageVersion>
         <Title>Tinkoff Invest .NET SDK</Title>
@@ -20,8 +20,12 @@
       <OutputPath>..\..\bin\Release\</OutputPath>
     </PropertyGroup>
 
+    <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+	    <PackageReference Include="System.Text.Json" Version="5.0.0" />
+    </ItemGroup>
+
     <ItemGroup>
-      <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+	    <PackageReference Include="Macross.Json.Extensions" Version="1.5.0" />
     </ItemGroup>
 
 </Project>

--- a/src/Tinkoff.Trading.OpenApi/Tinkoff.Trading.OpenApi.csproj
+++ b/src/Tinkoff.Trading.OpenApi/Tinkoff.Trading.OpenApi.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
         <Company>Tinkoff</Company>
-        <PackageVersion>1.6.0</PackageVersion>
+        <PackageVersion>1.7.0</PackageVersion>
         <Title>Tinkoff Invest .NET SDK</Title>
         <Authors>Nikita Kamensky</Authors>
         <PackageProjectUrl>https://tinkoffcreditsystems.github.io/invest-openapi/</PackageProjectUrl>

--- a/tests/Tinkoff.Trading.OpenApi.Tests/StreamingResponseTests.cs
+++ b/tests/Tinkoff.Trading.OpenApi.Tests/StreamingResponseTests.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-
+using System.Text.Json;
 using FluentAssertions;
-
-using Newtonsoft.Json;
 
 using Tinkoff.Trading.OpenApi.Models;
 using Tinkoff.Trading.OpenApi.Tests.TestHelpers;
@@ -16,7 +14,7 @@ namespace Tinkoff.Trading.OpenApi.Tests
         [Fact]
         public void DeserializeCandleTest()
         {
-            var streamingResponse = JsonConvert.DeserializeObject<StreamingResponse>(JsonFile.Read("streaming-candle-response"));
+            var streamingResponse = JsonSerializer.Deserialize<StreamingResponse>(JsonFile.Read("streaming-candle-response"), new JsonSerializerOptions(JsonSerializerDefaults.Web));
             var response = streamingResponse as StreamingResponse<CandlePayload>;
 
             var expectedResponse = new CandleResponse(
@@ -29,7 +27,7 @@ namespace Tinkoff.Trading.OpenApi.Tests
                     new DateTime(2019, 08, 07, 15, 35, 00, DateTimeKind.Utc),
                     CandleInterval.FiveMinutes,
                     "BBG0013HGFT4"),
-                new DateTime(2019, 08, 07, 15, 35, 01, 029, DateTimeKind.Utc).AddTicks(7213));
+                new DateTime(2019, 08, 07, 15, 35, 01, 029, DateTimeKind.Utc).AddTicks(7212));
 
             response.Should().BeEquivalentTo(expectedResponse);
         }

--- a/tests/Tinkoff.Trading.OpenApi.Tests/Tinkoff.Trading.OpenApi.Tests.csproj
+++ b/tests/Tinkoff.Trading.OpenApi.Tests/Tinkoff.Trading.OpenApi.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>
@@ -10,6 +10,7 @@
         <PackageReference Include="FluentAssertions" Version="5.10.3" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
         <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
+        <PackageReference Include="System.Text.Json" Version="5.0.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.core" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />


### PR DESCRIPTION
Закрывает #65.

Несколько особенностей возникших при миграции:

- Пришлось зареференсить `Macross.Json.Extensions`, потому что `System.Text.Json` не поддерживает `EnumMember` https://github.com/dotnet/runtime/issues/31081
- Небольшая несовместимость в округлении миллисекунд, `Newtonsoft.Json` именно округляет миллисекунды, `System.Text.Json` делает Truncate, поэтому пришлось подправить тест [DeserializeCandleTest](https://github.com/TinkoffCreditSystems/invest-openapi-csharp-sdk/compare/master...olsh:system-text-json?expand=1#diff-b6d07bf566d9ef36c899c76946e7b65d9be417fc744761ff3e651ddd1c0362e0R30)
- Использована опция `JsonSerializerDefaults.Web` для более безболезненной миграции. С этой опцией игнорируется кейс свойств, как и в `Newtonsoft.Json`. Начиная с 5 версии `System.Text.Json` [эта опция не особо влияет на производительность](https://devblogs.microsoft.com/dotnet/whats-next-for-system-text-json/#improved-deserialization-performance-for-case-insensitive-and-extra-property-cases). В случае с сериализацией `StreamingResponse` разницы не было.

Значительный прирост в производительности сериализации, код теста [тут](https://github.com/TinkoffCreditSystems/invest-openapi-csharp-sdk/issues/65#issuecomment-752076500)

|         Method |      Mean |     Error |    StdDev | Ratio |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------------- |----------:|----------:|----------:|------:|-------:|------:|------:|----------:|
| NewtonsoftJson | 36.728 us | 0.3493 us | 0.3267 us |  1.00 | 5.1270 |     - |     - |  15.88 KB |
| SystemTextJson |  9.706 us | 0.1114 us | 0.0988 us |  0.26 | 0.6104 |     - |     - |   1.88 KB |