### PR TITLE
Add overloads for connections

### DIFF
--- a/src/Tinkoff.Trading.OpenApi/Network/Connection.cs
+++ b/src/Tinkoff.Trading.OpenApi/Network/Connection.cs
@@ -23,6 +23,11 @@ namespace Tinkoff.Trading.OpenApi.Network
         private ClientWebSocket _webSocket;
         private Task _webSocketTask;
 
+        protected Connection(string baseUri, string token, HttpClient httpClient) 
+            : this (baseUri, "wss://api-invest.tinkoff.ru/openapi/md/v1/md-openapi/ws", token, httpClient)
+        {
+        }
+
         protected Connection(string baseUri, string webSocketBaseUri, string token, HttpClient httpClient)
         {
             _baseUri = new Uri(baseUri);
@@ -226,6 +231,11 @@ namespace Tinkoff.Trading.OpenApi.Network
 
     public class Connection : Connection<Context>
     {
+        public Connection(string token, HttpClient httpClient)
+            : base("https://api-invest.tinkoff.ru/openapi/", token, httpClient)
+        {
+        }
+
         public Connection(string baseUri, string webSocketBaseUri, string token, HttpClient httpClient)
             : base(baseUri, webSocketBaseUri, token, httpClient)
         {

--- a/src/Tinkoff.Trading.OpenApi/Network/ConnectionFactory.cs
+++ b/src/Tinkoff.Trading.OpenApi/Network/ConnectionFactory.cs
@@ -4,10 +4,6 @@ namespace Tinkoff.Trading.OpenApi.Network
 {
     public class ConnectionFactory
     {
-        private const string BaseUri = "https://api-invest.tinkoff.ru/openapi/";
-        private const string SandboxBaseUri = "https://api-invest.tinkoff.ru/openapi/sandbox/";
-        private const string WebSocketBaseUri = "wss://api-invest.tinkoff.ru/openapi/md/v1/md-openapi/ws";
-        
         /// <summary>
         /// Создаёт объект подключения к OpenAPI.
         /// </summary>
@@ -15,7 +11,7 @@ namespace Tinkoff.Trading.OpenApi.Network
         /// <returns>Подключение к бирже.</returns>
         public static Connection GetConnection(string token)
         {
-            return new Connection(BaseUri, WebSocketBaseUri, token, new HttpClient());
+            return new Connection(token, new HttpClient());
         }
 
         /// <summary>
@@ -25,7 +21,7 @@ namespace Tinkoff.Trading.OpenApi.Network
         /// <returns>Подключение к бирже в режиме песочницы.</returns>
         public static SandboxConnection GetSandboxConnection(string token)
         {
-            return new SandboxConnection(SandboxBaseUri, WebSocketBaseUri, token, new HttpClient());
+            return new SandboxConnection(token, new HttpClient());
         }
     }
 }

--- a/src/Tinkoff.Trading.OpenApi/Network/SandboxConnection.cs
+++ b/src/Tinkoff.Trading.OpenApi/Network/SandboxConnection.cs
@@ -4,6 +4,11 @@ namespace Tinkoff.Trading.OpenApi.Network
 {
     public class SandboxConnection : Connection<SandboxContext>
     {
+        public SandboxConnection(string token, HttpClient httpClient)
+            : base("https://api-invest.tinkoff.ru/openapi/sandbox/", token, httpClient)
+        {
+        }
+
         public SandboxConnection(string baseUri, string webSocketBaseUri, string token, HttpClient httpClient)
             : base(baseUri, webSocketBaseUri, token, httpClient)
         {


### PR DESCRIPTION
Добавлены перегрузки для тех случаев когда необходимо сконфигурировать HttpClient, но с дефолтными ендпоинтами.
Сейчас приходится делать так:
```csharp
new Connection("https://api-invest.tinkoff.ru/openapi/", "wss://api-invest.tinkoff.ru/openapi/md/v1/md-openapi/ws", token, httpClient);
```
Можно будет так
```csharp
new Connection(token, httpClient);
```