### PR TITLE
Readme fix, Code tests/ unused scopes and NL fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ dotnet build -c Release
 ```bash
 docker run --rm  -v "$PWD":/home/dotnet/project -w  /home/dotnet/project mcr.microsoft.com/dotnet/core/sdk:3.0 dotnet build -c Release
 ```
-После успешной сборки в поддиректрии `bin/Release/netstandard2.0` появится файл `Tinkoff.Trading.OpenApi.dll`, который можно подключить к любому другому .NET-проекту.
+После успешной сборки в поддиректории `bin/Release/netstandard2.0` появится файл `Tinkoff.Trading.OpenApi.dll`, который можно подключить к любому другому .NET-проекту.
 
 ### Где взять токен аутентификации?
 

--- a/samples/TradingBot/SandboxBot.cs
+++ b/samples/TradingBot/SandboxBot.cs
@@ -41,11 +41,9 @@ namespace TradingBot
             var now = DateTime.Now;
             var candleList = await _context.MarketCandlesAsync(randomInstrument.Figi, now.AddMinutes(-5), now, CandleInterval.Minute);
             foreach (var candle in candleList.Candles)
-            {
                 Console.WriteLine(candle);
-            }
-            Console.WriteLine();
 
+            Console.WriteLine();
             Console.WriteLine("Buy 1 lot");
             await _context.PlaceMarketOrderAsync(new MarketOrder(randomInstrument.Figi, 1, OperationType.Buy,
                 _accountId));
@@ -64,7 +62,8 @@ namespace TradingBot
         {
             var portfolio = await _context.PortfolioCurrenciesAsync(_accountId);
             Console.WriteLine("Balance");
-            foreach (var currency in portfolio.Currencies) Console.WriteLine($"{currency.Balance} {currency.Currency}");
+            foreach (var currency in portfolio.Currencies) 
+                Console.WriteLine($"{currency.Balance} {currency.Currency}");
 
             Console.WriteLine();
         }


### PR DESCRIPTION
There was a typo "subdirecory", replaced by "subdirectory".
Parentheses that were not needed in line 43 of samples/TradingBot/SandboxBot.cs have been removed.

Была опечатка "поддиректрии", заменена на "поддиректории".
Были убраны скобки, которые не нужны были в 43 строчке samples/TradingBot/SandboxBot.cs.